### PR TITLE
Fixes: TypeError: TuyaEntity._handle_state_update() takes 2 positional arguments but 3 were given

### DIFF
--- a/custom_components/tuya_climate_mult_edit/__init__.py
+++ b/custom_components/tuya_climate_mult_edit/__init__.py
@@ -220,16 +220,26 @@ class DeviceListener(SharingDeviceListener):
         self, device: CustomerDevice, updated_status_properties: list[str] | None
     ) -> None:
         """Update device status."""
+        # Extract updated status values for the properties that changed
+        updated_status = None
+        if updated_status_properties:
+            updated_status = {
+                prop: self.manager.device_map[device.id].status.get(prop)
+                for prop in updated_status_properties
+            }
+        
         LOGGER.debug(
-            "Received update for device %s: %s (updated properties: %s)",
+            "Received update for device %s: %s (updated properties: %s, values: %s)",
             device.id,
             self.manager.device_map[device.id].status,
             updated_status_properties,
+            updated_status,
         )
         dispatcher_send(
             self.hass,
             f"{TUYA_HA_SIGNAL_UPDATE_ENTITY}_{device.id}",
             updated_status_properties,
+            updated_status,
         )
 
     def add_device(self, device: CustomerDevice) -> None:

--- a/custom_components/tuya_climate_mult_edit/entity.py
+++ b/custom_components/tuya_climate_mult_edit/entity.py
@@ -288,8 +288,16 @@ class TuyaEntity(Entity):
         )
 
     async def _handle_state_update(
-        self, updated_status_properties: list[str] | None
+        self,
+        updated_status_properties: list[str] | None,
+        updated_status: dict[str, Any] | None = None,
     ) -> None:
+        """Handle state update from dispatcher.
+        
+        Args:
+            updated_status_properties: List of property names that were updated
+            updated_status: Dictionary of updated property values
+        """
         self.async_write_ha_state()
 
     def _send_command(self, commands: list[dict[str, Any]]) -> None:

--- a/custom_components/tuya_climate_mult_edit/manifest.json
+++ b/custom_components/tuya_climate_mult_edit/manifest.json
@@ -44,5 +44,5 @@
   "iot_class": "cloud_push",
   "loggers": ["tuya_iot"],
   "requirements": ["tuya-device-sharing-sdk==0.2.1"],
-  "version": "2025.03.0"
+  "version": "2025.11.0"
 }


### PR DESCRIPTION
### Root Cause
The official Home Assistant Tuya integration was updated to pass two arguments to `_handle_state_update()`:
1. `updated_status_properties` - List of updated property names
2. `updated_status` - Dictionary of updated values

The custom component only expected one argument, causing a signature mismatch.

### Solution
Updated the method signature and dispatcher call to handle both arguments:

#### Changes in `entity.py`
- Added `updated_status: dict[str, Any] | None = None` parameter to `_handle_state_update()`
- Added docstring documenting both parameters
- Maintained backward compatibility with default value

#### Changes in `__init__.py`
- Extract updated status values from device status
- Pass both arguments to `dispatcher_send()`
- Enhanced debug logging to include updated values

#### Changes in `manifest.json`
- Bumped version from 2025.03.0 to 2025.11.0

#### Tests
Changes tested on Home Assistant Core 2025.11.1 Frontend 20251105.0